### PR TITLE
Allow auto merge when some workflow runs are skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This workflow requires a github token  with read/write access to all the reposit
 Any PRs that meet the following criteria will be automerged:
 - PR is open
 - PR is mergeable
-- PR is passing test
+- PR is passing all PR checks (skipped checks count as passed)
 - PR is approved by at least one reviewer
 - PR is up-to-date with the base branch
 
 Any PR with the following criteria will be updated and test will be run before merging:
 - PR is open
 - PR is approved
-- PR is passing PR Tests
+- PR is passing all PR checks (skipped checks count as passed)
 - PR is out-of-date
 
 A Github App is required to generate the appropriate Permissions for Automerge to work.

--- a/src/automerge.py
+++ b/src/automerge.py
@@ -93,7 +93,7 @@ for pr in automerge_prs:
     base_branch = repo.get_branch(pr.base.ref)
     commit = [c for c in pr.get_commits() if c.sha == pr.head.sha][0]
     commit_check_runs = commit.get_check_runs()
-    all_checks_passed = all(run.conclusion == "success" for run in commit_check_runs)
+    all_checks_passed = all(run.conclusion in ("success", "skipped") for run in commit_check_runs)
     _LOGGER.debug(f'HEAD Commit: {commit}')
     _LOGGER.debug(f'All Checks Passed? {all_checks_passed}')
     if args.dry_run:


### PR DESCRIPTION
This PR allows the automerge to merge PRs when all checks are passed **or skipped**. Previously, skipped checks blocked the automerger.